### PR TITLE
debian: decrease required cmake version

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -2,7 +2,7 @@ Source: seacas
 Priority: extra
 Maintainer: Nico Schlömer <nico.schloemer@gmail.com>
 Build-Depends: debhelper (>= 9),
-  cmake (>= 3.0.0),
+  cmake (>= 2.8.12),
   gfortran,
   libhdf5-dev,
   libmatio-dev,


### PR DESCRIPTION
This corresponds with TriBits's requirement.